### PR TITLE
Set maximum delay for stop bit.

### DIFF
--- a/NewRemoteReceiver.cpp
+++ b/NewRemoteReceiver.cpp
@@ -122,7 +122,7 @@ void RECEIVE_ATTR NewRemoteReceiver::interruptHandler() {
 		// wait for the long low part of a stop bit.
 		// Stopbit: 1T high, 40T low
 		// By default 1T is 260µs, but for maximum compatibility go as low as 120µs
-		if (duration > 4800) { // =40*120µs, minimal time between two edges before decoding starts.
+		if (duration > 4800 && duration < 15000) { // =40*120µs, minimal time between two edges before decoding starts.
 			// Sync signal received.. Preparing for decoding
 			repeats = 0;
 


### PR DESCRIPTION
In my environment, 433MHz is quite noisy and there are
plenty of spikes. This triggers in state -1, with a big duration (~65000).
Thus, the min1Period gets a big value, and all of the received pulses get skipped
because "too short". The state machine stays forever in state 0, with all pulses skipped.
Setting a maximum duration value prevents this livelock.