### PR TITLE
Fix callbacks, add ESP32 support, and Github Action Compile Test

### DIFF
--- a/.github/workflows/CompileTest.yml
+++ b/.github/workflows/CompileTest.yml
@@ -1,0 +1,124 @@
+# This is the name of the workflow, visible on GitHub UI.
+name: 'Compile Tests'
+
+#description: 'Run the Arduino CLI to compile example sketches and check if compiles fine for multiple boards'
+#author: 'Jorge Rivera'
+
+# Controls when the action will run. 
+# Here we tell GitHub to run the workflow when a commit.
+on:
+  # Triggers the workflow on push or pull request events
+  push:
+    paths:
+      - '*.h'
+      - '*.cpp'
+      - '**.ino'
+      - '.github/workflows/*.yml'
+
+  pull_request:
+    paths:
+      - '*.h'
+      - '*.cpp'
+      - '**.ino'
+      - '.github/workflows/*.yml'
+  
+  schedule:
+    - cron:  '0 0 1 * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# This is the list of jobs that will be run concurrently.
+# Since we use a build matrix, the actual number of jobs
+# started depends on how many configurations the matrix
+# will produce.
+jobs:
+  boards:
+    # This is the name of the job
+    name: "Compile test for ${{ matrix.config.board }}"
+    
+    # This is the platform GitHub will use to run our workflow
+    runs-on: ubuntu-latest
+    
+    # Here we tell GitHub that the jobs must be determined
+    # dynamically depending on a matrix configuration.
+    strategy:
+      
+      # Set to false so that GitHub does not cancel all jobs
+      # in progress if any array job fails.
+      fail-fast: false
+      
+      # The matrix will produce one job for each configuration:
+      matrix:
+        config:
+          - board: "Arduino Nano"
+            fqbn: "arduino:avr:nano"
+            platform: "arduino:avr"
+
+          - board: "ESP8266 NodeMCUv2"
+            fqbn: "esp8266:esp8266:d1_mini"
+            platform: "esp8266:esp8266"
+            additional-url: "--additional-urls https://arduino.esp8266.com/stable/package_esp8266com_index.json"
+
+          - board: "ESP8266 Wemos D1 Mini (@2.7.4)"
+            fqbn: "esp8266:esp8266:nodemcuv2"
+            platform: "esp8266:esp8266@2.7.4"
+            additional-url: "--additional-urls https://arduino.esp8266.com/stable/package_esp8266com_index.json"
+            
+          - board: "ESP32 NodeMCU-32S"
+            fqbn: "esp32:esp32:nodemcu-32s"
+            platform: "esp32:esp32"
+            additional-url: "--additional-urls https://dl.espressif.com/dl/package_esp32_index.json"
+
+    # This is the list of steps this job will run.
+    steps:
+      # We use the "arduino/setup-arduino-cli" action to install and
+      # configure the Arduino CLI on the system.
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v1.1.1
+
+      # We then install the platform, which one will be determined
+      # dynamically by the build matrix.
+      - name: Install platform ${{ matrix.config.platform }} 
+        run: |
+          arduino-cli config init -v ${{ matrix.config.additional-url }}
+          arduino-cli core update-index -v 
+          arduino-cli core install -v ${{ matrix.config.platform }} --run-post-install
+
+      # First of all, we clone the repo using the "checkout" action.
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Finally, we compile the sketches, using the FQBN that was set in the boards matrix.
+      - name: Compile examples for ${{ matrix.config.board }}
+        id: compile
+        env: 
+          fqbn: ${{ matrix.config.fqbn }}
+        run: |
+          # Compile example sketches:
+          export errors=()
+          for sketch in $( find ./examples -name "*.ino"|sed "s/\ /__ESPACE__/g" )
+          do
+            sketch_path=$( echo $sketch |sed "s/__ESPACE__/\ /g" )
+            sketch_name=$( echo $sketch_path |sed "s/.*\///" )
+            echo -e "\033[34;1;4mCompile example sketch: $sketch_path\033[0m"
+            arduino-cli compile --fqbn ${{ matrix.config.fqbn }} --warnings more \
+              --library ../NewRemoteSwitch "$sketch_path" \
+            || { errors+=($sketch) ; echo -e "\033[31;1;4mERROR COMPILING SKETCH: $sketch_path\033[0m\r\n" ;}
+          done
+          echo ::set-output name=errors::${errors[@]}
+
+      # Show errors
+      - name: Show errors
+        if: ${{ steps.compile.outputs.errors }}
+        env: 
+          errors: ${{ steps.compile.outputs.errors }}
+        run: |
+          #  Show errors
+          for sketch in $errors 
+          do
+            sketch_path=$( echo $sketch |sed "s/__ESPACE__/\ /g" )
+            echo -e "\033[31;1;4mERROR COMPILING SKETCH: $sketch_path\033[0m"
+          done
+          exit 1

--- a/NewRemoteReceiver.cpp
+++ b/NewRemoteReceiver.cpp
@@ -36,14 +36,17 @@ A full frame looks like this:
 
 ************/
 
-#ifdef ESP8266
+#if defined ESP8266 
     // interrupt handler and related code must be in RAM on ESP8266,
     #define RECEIVE_ATTR ICACHE_RAM_ATTR
-	#define CALLBACK_SIGNATURE (_callback)(receivedCode.period, receivedCode.address, receivedCode.groupBit, receivedCode.unit, receivedCode.switchType, receivedCode.dimLevelPresent, receivedCode.dimLevel)
+#elif defined ESP32
+	// interrupt handler and related code must be in RAM on ESP32	
+	#define RECEIVE_ATTR IRAM_ATTR
 #else
     #define RECEIVE_ATTR
-	#define CALLBACK_SIGNATURE (_callback)(receivedCode.period, receivedCode.address, receivedCode.groupBit, receivedCode.unit, receivedCode.switchType, receivedCode.dimLevelPresent, receivedCode.dimLevel)
 #endif
+
+#define CALLBACK_SIGNATURE (_callback)(receivedCode.period, receivedCode.address, receivedCode.groupBit, receivedCode.unit, receivedCode.switchType, receivedCode.dimLevelPresent, receivedCode.dimLevel)
 
 int8_t NewRemoteReceiver::_interrupt;
 volatile short NewRemoteReceiver::_state;

--- a/NewRemoteReceiver.h
+++ b/NewRemoteReceiver.h
@@ -30,7 +30,7 @@ struct NewRemoteCode {
 	byte dimLevel;				// Dim level [0..15]. Will be available if switchType is dim, on_with_dim or off_with_dim.
 };
 
-#ifdef ESP8266
+#if defined ESP8266 || defined ESP32
 #include <functional>
 #define CALLBACK_SIGNATUREH typedef std::function<void(unsigned int period, unsigned long address, unsigned long groupBit, unsigned long unit, unsigned long switchType, boolean dimLevelPresent, byte dimLevel)> NewRemoteReceiverCallBack
 // Type definition for callback function with NewRemoteCode struct as parameter

--- a/NewRemoteTransmitter.cpp
+++ b/NewRemoteTransmitter.cpp
@@ -6,12 +6,6 @@
  */
 
 #include "NewRemoteTransmitter.h"
-#ifdef ESP8266
-    // interrupt handler and related code must be in RAM on ESP8266,
-    #define RECEIVE_ATTR ICACHE_RAM_ATTR
-#else
-    #define RECEIVE_ATTR
-#endif
 
 NewRemoteTransmitter::NewRemoteTransmitter(unsigned long address, byte pin, unsigned int periodusec, byte repeats) {
 	_address = address;

--- a/examples/LearnCode/LearnCode.ino
+++ b/examples/LearnCode/LearnCode.ino
@@ -4,14 +4,14 @@
  *
  * For details, see NewRemoteReceiver.h!
  *
- * With this sketch you can control a LED connected to digital pin 13,
+ * With this sketch you can control a LED connected to LED_BUILTIN pin,
  * after the sketch learned the code. After start, the LED starts to blink,
  * until a valid code has been received. The led stops blinking. Now you
  * can control the LED with the remote.
  *
  * Note: only unit-switches are supported in this sketch, no group or dim.
  *
- * Set-up: connect the receiver to digital pin 2 and a LED to digital pin 13.
+ * Set-up: connect the receiver to an attachable interruption pin. See below.
  */
 
 #include <NewRemoteReceiver.h>
@@ -20,20 +20,46 @@ boolean codeLearned = false;
 unsigned long learnedAddress;
 byte learnedUnit;
 
+#if !defined LED_BUILTIN
+  #if defined ESP8266 || defined ESP32
+    #define LED_BUILTIN 2
+  #else
+    #define LED_BUILTIN 13
+  #endif
+  #define VALUE_TO_STRING(x) #x
+  #define VALUE(x) VALUE_TO_STRING(x)
+  #pragma message("SETTING LED_BUILTIN TO PIN " VALUE(LED_BUILTIN))
+#endif
+
 void setup() {
   // LED-pin as output
-  pinMode(13, OUTPUT);
+  pinMode(LED_BUILTIN, OUTPUT);
 
-  // Init a new receiver on interrupt pin 0, minimal 2 identical repeats, and callback set to processCode.
-  NewRemoteReceiver::init(0, 2, processCode);
+  // Initialize receiver on interrupt 0 (= digital pin 2) for Arduino Uno.
+  // On ESP8266 and ESP32 use on GPIO 5 = digital pin depends board.
+  // Review file "pins_arduino.h" of your variant:
+  //   https://github.com/esp8266/Arduino/tree/master/variants
+  //   https://github.com/espressif/arduino-esp32/tree/master/variants
+  //
+  // See the interrupt-parameter of attachInterrupt for possible values (and pins)
+  // to connect the receiver.
+  //
+  // Calls the callback "processCode" after 2 identical codes have been received
+  // in a row. (thus, keep the button pressed for a moment).
+
+    #if defined ESP8266 || defined ESP32
+      NewRemoteReceiver::init(5, 2, processCode);
+    #else
+      NewRemoteReceiver::init(0, 2, processCode);
+    #endif
 }
 
 void loop() {
   // Blink led until a code has been learned
   if (!codeLearned) {
-    digitalWrite(13, HIGH);
+    digitalWrite(LED_BUILTIN, HIGH);
     delay(500);
-    digitalWrite(13, LOW);
+    digitalWrite(LED_BUILTIN, LOW);
     delay(500);
   }
 }
@@ -55,9 +81,9 @@ void processCode(NewRemoteCode receivedCode) {
       // Switch the LED off if the received code was "off".
       // Anything else (on, dim, on_with_dim) will switch the LED on.
       if (receivedCode.switchType == NewRemoteCode::off) {
-        digitalWrite(13, LOW);
+        digitalWrite(LED_BUILTIN, LOW);
       } else {
-        digitalWrite(13, HIGH);
+        digitalWrite(LED_BUILTIN, HIGH);
       }
     }
   }

--- a/examples/LightShow/LightShow.ino
+++ b/examples/LightShow/LightShow.ino
@@ -2,7 +2,7 @@
  * Demo for RF remote switch receiver.
  * For details, see NewRemoteReceiver.h!
  *
- * Connect the transmitter to digital pin 11.
+ * Connect the transmitter to digital pin 11 on Arduino or pin 4 on ESP8266 and ESP32.
  *
  * This sketch demonstrates the use of the NewRemoteTransmitter class.
  *
@@ -19,10 +19,14 @@
 
 #include <NewRemoteTransmitter.h>
 
-// Create a transmitter on address 123, using digital pin 11 to transmit, 
+// Create a transmitter on address 123, using a digital pin to transmit, 
 // with a period duration of 260ms (default), repeating the transmitted
 // code 2^3=8 times.
+#if defined ESP8266 || defined ESP32
+NewRemoteTransmitter transmitter(123, 4, 260, 3);
+#else
 NewRemoteTransmitter transmitter(123, 11, 260, 3);
+#endif
 
 void setup() {
 }

--- a/examples/Retransmitter/Retransmitter.ino
+++ b/examples/Retransmitter/Retransmitter.ino
@@ -2,7 +2,11 @@
  * Demo for RF remote switch receiver.
  * For details, see NewRemoteReceiver.h!
  *
- * Connect the transmitter to digital pin 11, and the receiver to digital pin 2.
+ * Connect the receiver to an attachable interruption pin. See below.
+ * Connect the transmitter to digital pin 11 on Arduino or pin 4 on ESP8266 and ESP32.
+ * 
+ * To prevent kernel panic for interrupt wdt timeout on ESP8266 and ESP32, 
+ * the retransmission of the received code is done in loop() function.
  *
  * When run, this sketch waits for a valid code from a new-style the receiver,
  * decodes it, and retransmits it after 5 seconds.
@@ -11,53 +15,74 @@
 #include <NewRemoteReceiver.h>
 #include <NewRemoteTransmitter.h>
 
+
+NewRemoteCode receivedCode;   // Global var to store received code for retramitt it
+boolean codeLearned = false;  // Flag to set a valid learned code has been received
+
 void setup() {
   // See example ShowReceivedCode for info on this
-  NewRemoteReceiver::init(0, 2, retransmitter);
+  #if defined ESP8266 || defined ESP32
+    NewRemoteReceiver::init(5, 2, retransmitter);
+  #else
+    NewRemoteReceiver::init(0, 2, retransmitter);
+  #endif
 }
 
 void loop() {
+
+  if (codeLearned) {
+
+    // Clear flag
+    codeLearned = false;
+
+    // Wait 5 seconds before sending.
+    delay(5000);
+
+    // Create a new transmitter with the received address and period, use a digital pin as output pin
+    #if defined ESP8266 || defined ESP32
+    NewRemoteTransmitter transmitter(receivedCode.address, 4, receivedCode.period);
+    #else
+    NewRemoteTransmitter transmitter(receivedCode.address, 11, receivedCode.period);
+    #endif
+
+    if (receivedCode.switchType == NewRemoteCode::dim || 
+      (receivedCode.switchType == NewRemoteCode::on && receivedCode.dimLevelPresent)) {
+      // Dimmer signal received
+
+      if (receivedCode.groupBit) {
+        transmitter.sendGroupDim(receivedCode.dimLevel);
+      } 
+      else {
+        transmitter.sendDim(receivedCode.unit, receivedCode.dimLevel);
+      }
+    } 
+    else {
+      // On/Off signal received
+      bool isOn = receivedCode.switchType == NewRemoteCode::on;
+
+      if (receivedCode.groupBit) {
+        // Send to the group
+        transmitter.sendGroup(isOn);
+      } 
+      else {
+        // Send to a single unit
+        transmitter.sendUnit(receivedCode.unit, isOn);
+      }
+    }
+
+    NewRemoteReceiver::enable();
+  }
 }
 
-void retransmitter(NewRemoteCode receivedCode) {
+void retransmitter(NewRemoteCode retransmitterCode) {  
+
   // Disable the receiver; otherwise it might pick up the retransmit as well.
   NewRemoteReceiver::disable();
 
-  // Need interrupts for delay()
-  interrupts();
+  // Store received code for retramitt it in loop()
+  receivedCode = retransmitterCode;
+  // Set valid learned code has been received
+  codeLearned = true;
 
-  // Wait 5 seconds before sending.
-  delay(5000);
-
-  // Create a new transmitter with the received address and period, use digital pin 11 as output pin
-
-  NewRemoteTransmitter transmitter(receivedCode.address, 11, receivedCode.period);
-
-  if (receivedCode.switchType == NewRemoteCode::dim || 
-    (receivedCode.switchType == NewRemoteCode::on && receivedCode.dimLevelPresent)) {
-    // Dimmer signal received
-
-    if (receivedCode.groupBit) {
-      transmitter.sendGroupDim(receivedCode.dimLevel);
-    } 
-    else {
-      transmitter.sendDim(receivedCode.unit, receivedCode.dimLevel);
-    }
-  } 
-  else {
-    // On/Off signal received
-    bool isOn = receivedCode.switchType == NewRemoteCode::on;
-
-    if (receivedCode.groupBit) {
-      // Send to the group
-      transmitter.sendGroup(isOn);
-    } 
-    else {
-      // Send to a single unit
-      transmitter.sendUnit(receivedCode.unit, isOn);
-    }
-  }
-
-  NewRemoteReceiver::enable();
 }
 

--- a/examples/ShowReceivedCode/ShowReceivedCode.ino
+++ b/examples/ShowReceivedCode/ShowReceivedCode.ino
@@ -3,12 +3,13 @@
 * For details, see RemoteReceiver.h!
 *
 * This sketch shows the received signals on the serial port.
-* Connect the receiver to digital pin 2 on arduino and digital pin 1 on ESP8266.
+* Connect the receiver to an attachable interruption pin. See below.
 * Detected codes example:
  Code: 8233372 Period: 273
  unit: 1
  groupBit: 0
  switchType: 0
+ dimLevel: 3
 */
 
 #include <NewRemoteReceiver.h>
@@ -16,16 +17,21 @@
 void setup() {
   Serial.begin(115200);
 
-  // Initialize receiver on interrupt 0 (= digital pin 2) for arduino uno, calls the callback "showCode"
-  // after 1 identical codes have been received in a row. (thus, keep the button pressed
-  // for a moment), on esp8266 use on interrupt 5 = digital pin 1
+  // Initialize receiver on interrupt 0 (= digital pin 2) for Arduino Uno. 
+  // On ESP8266 and ESP32 use on GPIO 5 = digital pin depends board. 
+  // Review file "pins_arduino.h" of your variant:
+  //   https://github.com/esp8266/Arduino/tree/master/variants
+  //   https://github.com/espressif/arduino-esp32/tree/master/variants
   //
   // See the interrupt-parameter of attachInterrupt for possible values (and pins)
   // to connect the receiver.
+  //
+  // Calls the callback "showCode" after 2 identical codes have been received 
+  // in a row. (thus, keep the button pressed for a moment).
 
   // if you don't see codes try to reset your board after upload
   
-    #ifdef ESP8266
+    #if defined ESP8266 || defined ESP32
       NewRemoteReceiver::init(5, 2, showCode);
     #else
       NewRemoteReceiver::init(0, 2, showCode);

--- a/examples/ShowReceivedCode/ShowReceivedCode.ino
+++ b/examples/ShowReceivedCode/ShowReceivedCode.ino
@@ -38,7 +38,7 @@ void loop() {
 }
 
 // Callback function is called only when a valid code is received.
-void showCode(unsigned int period, unsigned long address, unsigned long groupBit, unsigned long unit, unsigned long switchType) {
+void showCode(unsigned int period, unsigned long address, unsigned long groupBit, unsigned long unit, unsigned long switchType, boolean dimLevelPresent, byte dimLevel) {
 
   // Print the received code.
   Serial.print("Code: ");
@@ -51,5 +51,10 @@ void showCode(unsigned int period, unsigned long address, unsigned long groupBit
   Serial.println(groupBit);
   Serial.print(" switchType: ");
   Serial.println(switchType);
+
+  if (dimLevelPresent){
+    Serial.print(" dimLevel: ");
+    Serial.println(dimLevel);    
+  }
 
 }


### PR DESCRIPTION
Hi!

I have made some fixes in the library, which I think are useful, so I would like to share them with other users.

There are three commits:

- The first commit is for fix the call to the callback function, which sometimes had a structure as parameter, and at other times had several discrete parameters. This was working by chance on 8-bit architecture like AVR, but 32-bit architectures like ESP8266 and ESP32 were impossible to get to work, even forcing the pointer casting. Since I have no criteria to select one mode or the other, I have overloaded the init() function so that either of the two callback modes can be used.

- In the second commit, a Github Action is added to compiles the library with all its examples in different platforms like **Arduino Nano, ESP8266 NodeMCUv2 or ESP32 NodeMCU-32S**, to at least, be sure that compilation is successful. https://github.com/latchdevel/NewRemoteSwitch/actions/workflows/CompileTest.yml

- And in the third commit, full compatibility with ESP32 is added and the examples are tweaked to work correctly on ESP32 and ESP8266.

In addition to the compilation tests, I have tested the four examples in a real environment, both on Arduino AVR as ESP8266 and ESP32, all working correctly.

Hope I can help other users with my little contribution.
Regards!

